### PR TITLE
Fixed sending response templates

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -24,3 +24,6 @@ bower_components
 
 # Service account keys
 service_account_key.json
+
+# Local copy of toml file
+isthislegit.toml

--- a/dashboard/app/views.py
+++ b/dashboard/app/views.py
@@ -88,6 +88,7 @@ def templates():
             name=form.name.data,
             text=form.text.data,
             subject=form.subject.data,
+            sender=g.user.email(),
             owner_domain=g.domain,
             created_by=g.user.email())
         template.put()

--- a/dashboard/models/__init__.py
+++ b/dashboard/models/__init__.py
@@ -1,0 +1,1 @@
+ISTHISLEGIT_SVC = 'IsThisLegit-Service-Account'

--- a/dashboard/models/event.py
+++ b/dashboard/models/event.py
@@ -2,8 +2,10 @@ from google.appengine.ext import ndb
 
 from config import config
 from models.util import DateTimeProperty
+from models import ISTHISLEGIT_SVC
 from services.webhook import webhook_provider
 from services.worker import worker_provider
+
 
 class Event(ndb.Model):
     """
@@ -13,7 +15,7 @@ class Event(ndb.Model):
     event_type = ndb.StringProperty(required=True)
     name = ndb.StringProperty(required=True)
     message = ndb.StringProperty(required=True)
-    created_by = ndb.StringProperty(default='IsThisLegit-Service-Account')
+    created_by = ndb.StringProperty(default=ISTHISLEGIT_SVC)
     details = ndb.JsonProperty()
 
     def _post_put_hook(self, future):
@@ -28,9 +30,8 @@ class Event(ndb.Model):
         future.check_success()
         for url in config['webhook']['urls']:
             worker_provider.add_task(
-                webhook_provider.send,
-                payload=self.to_dict()
-            )
+                webhook_provider.send, payload=self.to_dict())
+
 
 def EventReportCreated(*args, **kwargs):
     ''' Returns an event indicating a report was created.
@@ -45,26 +46,21 @@ def EventReportCreated(*args, **kwargs):
         created_by=report.reported_by,
         date_created=report.date_reported,
         message='{} submitted this report.'.format(report.reported_by),
-        details={
-            'report': report.to_dict()
-        }
-    )
+        details={'report': report.to_dict()})
+
 
 def EventReportResponded(*args, **kwargs):
     ''' Returns an event indicating a report has been responded to. '''
     response = kwargs.get('response')
     report = kwargs.get('report')
     return Event(
-        name = 'Response Created',
-        event_type = 'response_created',
-        message = '{} responded to this report as {}'.format(
-            response.responder, response.sender
-        ),
-        details={
-            'report': report.to_dict(),
-            'response': response.to_dict()
-        }
-    )
+        name='Response Created',
+        event_type='response_created',
+        message='{} responded to this report as {}'.format(
+            response.responder, response.sender),
+        details={'report': report.to_dict(),
+                 'response': response.to_dict()})
+
 
 def EventAttributeChanged(*args, **kwargs):
     ''' Returns an event indicating a report has had an attribute changed. '''
@@ -73,29 +69,23 @@ def EventAttributeChanged(*args, **kwargs):
     value = kwargs.get('value')
     report = kwargs.get('report')
     return Event(
-        created_by = creator,
-        name = 'Report Changed',
-        event_type = 'report_changed',
-        message = '{} has changed the {} of this report to {}'.format(
-            creator, attr, value
-        ),
-        details={
-            'attr': attr,
-            'value': value,
-            'report': report.to_dict()
-        }
-    )
+        created_by=creator,
+        name='Report Changed',
+        event_type='report_changed',
+        message='{} has changed the {} of this report to {}'.format(
+            creator, attr, value),
+        details={'attr': attr,
+                 'value': value,
+                 'report': report.to_dict()})
+
 
 def EventRuleMatch(*args, **kwargs):
     ''' Returns an event indicating a rule matched a report. '''
     rule = kwargs.get('rule')
     report = kwargs.get('report')
     return Event(
-        name = 'Rule Matched',
-        event_type = 'rule_matched',
-        message = 'Rule {} matched this report.'.format(rule.name),
-        details = {
-            'rule': rule.to_dict(),
-            'report': report.to_dict()
-        }
-    )
+        name='Rule Matched',
+        event_type='rule_matched',
+        message='Rule {} matched this report.'.format(rule.name),
+        details={'rule': rule.to_dict(),
+                 'report': report.to_dict()})

--- a/dashboard/models/rule.py
+++ b/dashboard/models/rule.py
@@ -1,6 +1,7 @@
 from google.appengine.ext import ndb
 
 import json
+import re
 
 from models.util import DateTimeProperty
 from models.email import EmailReport
@@ -57,7 +58,7 @@ class RuleCondition(ndb.Model):
             if self.value != "":
                 if self._text_match(self.matches, report.text, self.value):
                     matches = True
-                if self_text_match(self.matches, report.html, self.value):
+                if self.text_match(self.matches, report.html, self.value):
                     matches = True
         return matches
 
@@ -113,7 +114,7 @@ class Rule(ndb.Model):
         required_props = ['name']
         for prop in required_props:
             if not data.get(prop):
-                raise RuleValidationError(
+                raise RuleValidationException(
                     'Missing required field {}'.format(prop))
         '''
         for condition in data.get('conditions'):

--- a/dashboard/models/template.py
+++ b/dashboard/models/template.py
@@ -2,6 +2,7 @@ from google.appengine.ext import ndb
 
 from models.util import DateTimeProperty
 
+
 class Template(ndb.Model):
     """
     Template - represents an email Template used to respond to Email Reports
@@ -23,4 +24,4 @@ class Template(ndb.Model):
     @classmethod
     def get_by_name(cls, base_query, name):
         """ Returns the template that matches the given name."""
-        return base_query.query(cls.name == name).get()
+        return base_query.filter(cls.name == name).get()


### PR DESCRIPTION
This fixes some bugs in the process of sending response templates.

This also adds full templating in both quick replies and sending templates. So, you can now use values in a report model within your template (both in the subject and the body).