### PR TITLE
Validate SSL certificates.

### DIFF
--- a/dashboard/app.yaml
+++ b/dashboard/app.yaml
@@ -5,6 +5,9 @@ threadsafe: true
 builtins:
 - deferred: on
 
+env_variables:
+  PYTHONHTTPSVERIFY: 1
+
 handlers:
 - url: /static
   static_dir: static/dist


### PR DESCRIPTION
This updates the dashboard to follow the instructions at https://cloud.google.com/appengine/docs/standard/python/sockets/ssl_support#validating_certificates
and properly validate SSL certificates.